### PR TITLE
[NEST-FE-48] Removed i18n configuration in next.config.ts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,5 @@
 import type { NextConfig } from "next";
-import { i18n } from "./next-i18next.config";
 
-const nextConfig: NextConfig = {
-  i18n,
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;


### PR DESCRIPTION
Removed i18n config because unsupported in App router.